### PR TITLE
add progressive fallback wait for audacity pipes to be ready

### DIFF
--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -97,22 +97,20 @@ def do(command):  # type: (str) -> str
         read_pipe_name = "/tmp/audacity_script_pipe.from." + str(os.getuid())
         eol = "\n"
 
-    if not os.path.exists(write_pipe_name):
-        raise PyAudacityException(
-            write_pipe_name
-            + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
-        )
-        sys.exit()
+    for pipe in [write_pipe_name, read_pipe_name]:
+        # on macos it sometimes takes more than 0.1ms for the pipe(s) to be ready
+        for wait in [0.0001, 0.1, 0.2, 0.4, 0.8, 1.0]:
+            time.sleep(wait)
+            if os.path.exists(pipe):
+                # sys.stderr.write(f".Waited {wait} seconds\n") # DEBUG/note
+                break
 
-    # For reasons unknown, we need a slight pause after checking for the existence of the read file on Windows:
-    time.sleep(0.0001)
-
-    if not os.path.exists(read_pipe_name):
-        raise PyAudacityException(
-            read_pipe_name
-            + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
-        )
-        sys.exit()
+        if not pipe:
+            raise PyAudacityException(
+                pipe
+                + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
+            )
+            sys.exit()
 
     # For reasons unknown, we need a slight pause after checking for the existence of the read file on Windows:
     time.sleep(0.0001)


### PR DESCRIPTION
I was getting spurious exceptions when using your branch of this code to replace use of the generic `pipeclient.py` from the Audacity source.  I'd found, when using pipeclient, that I sometimes needed to wait longer for Audacity to be ready.  In a quick test run of this patch, most times a wait of 0.0001 would suffice, but sometimes it needed the 0.1s wait.  I'll submit a report to the main repo too -- but I've started by using yours as your sensible pull requests to main do not seem to have been acted upon.